### PR TITLE
Add DenseIdentity and ScaledDenseIdentity

### DIFF
--- a/helper.go
+++ b/helper.go
@@ -9,7 +9,7 @@ import (
 )
 
 // ScaledIdentity returns an identity matrix time a scaling factor of the provided size.
-func ScaledIdentity(n int, s float64) mat64.Symmetric {
+func ScaledIdentity(n int, s float64) *mat64.SymDense {
 	vals := make([]float64, n*n)
 	for j := 0; j < n*n; j++ {
 		if j%(n+1) == 0 {
@@ -21,8 +21,26 @@ func ScaledIdentity(n int, s float64) mat64.Symmetric {
 	return mat64.NewSymDense(n, vals)
 }
 
+// DenseIdentity returns an identity matrix of type Dense and of the provided size.
+func DenseIdentity(n int) *mat64.Dense {
+	return ScaledDenseIdentity(n, 1)
+}
+
+// ScaledDenseIdentity returns an identity matrix time of type Dense a scaling factor of the provided size.
+func ScaledDenseIdentity(n int, s float64) *mat64.Dense {
+	vals := make([]float64, n*n)
+	for j := 0; j < n*n; j++ {
+		if j%(n+1) == 0 {
+			vals[j] = s
+		} else {
+			vals[j] = 0
+		}
+	}
+	return mat64.NewDense(n, n, vals)
+}
+
 // Identity returns an identity matrix of the provided size.
-func Identity(n int) mat64.Symmetric {
+func Identity(n int) *mat64.SymDense {
 	return ScaledIdentity(n, 1)
 }
 

--- a/helper_test.go
+++ b/helper_test.go
@@ -40,17 +40,20 @@ func TestIsNil(t *testing.T) {
 
 func TestIdentity(t *testing.T) {
 	n := 3
-	i33 := Identity(n)
-	if r, c := i33.Dims(); r != n || r != c {
-		t.Fatalf("i11 has dimensions (%dx%d)", r, c)
-	}
-	for i := 0; i < n; i++ {
-		if i33.At(i, i) != 1 {
-			t.Fatalf("i33(%d,%d) != 1", i, i)
+	i33s := Identity(n)
+	i33d := DenseIdentity(n)
+	for _, i33 := range []mat64.Matrix{i33s, i33d} {
+		if r, c := i33.Dims(); r != n || r != c {
+			t.Fatalf("i11 has dimensions (%dx%d)", r, c)
 		}
-		for j := 0; j < n; j++ {
-			if i != j && i33.At(i, j) != 0 {
-				t.Fatalf("i33(%d,%d) != 0", i, j)
+		for i := 0; i < n; i++ {
+			if i33.At(i, i) != 1 {
+				t.Fatalf("i33(%d,%d) != 1", i, i)
+			}
+			for j := 0; j < n; j++ {
+				if i != j && i33.At(i, j) != 0 {
+					t.Fatalf("i33(%d,%d) != 0", i, j)
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Same as Identity and ScaledIdentity, but returns a *mat64.Dense instead
of *mat64.SymDense. Also in this change is the return of a concrete
instead of interface (as per go best practice).

Closes #29 .